### PR TITLE
Error if no buffer output

### DIFF
--- a/src/PHPStamp/Result.php
+++ b/src/PHPStamp/Result.php
@@ -39,7 +39,7 @@ class Result
             header('Content-Disposition: attachment;filename="' . $fileName . '"');
 
             // Send file - required ob_clean() & exit;
-            ob_clean();
+            if (ob_get_contents()) ob_clean();
             readfile($tempArchive);
             unlink($tempArchive);
             exit;


### PR DESCRIPTION
[2017-05-24 09:57:50] remote.ERROR: ErrorException: ob_clean(): failed to delete buffer. No buffer to delete in ...\vendor\shadz3rg\php-stamp\src\PHPStamp\Result.php:42