### PR TITLE
Now use doctrine/lexer instead of forked one...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-xsl": "*",
         "ext-zip": "*",
         "ext-dom": "*",
-        "shadz3rg/lexer": "^1.0"
+        "doctrine/lexer": "^1.0 || ^2.0"
     },
     "authors": [
         {


### PR DESCRIPTION
There is problem with forked doctrine/lexer lib on new versions of composer, if you are using doctrine/lexer independently.

thus in vendor/composer/autoload_static.php we have wrong order of libraries

```
        'Doctrine\\Common\\Lexer\\' =>
        array (
            0 => __DIR__ . '/..' . '/shadz3rg/lexer/lib/Doctrine/Common/Lexer',
            1 => __DIR__ . '/..' . '/doctrine/lexer/src',
        ),
```

which means that forked class of this lib will be loaded instead of required.

Was detected on 

```
composer --version                              
Composer version 2.9.7 2026-04-14 13:31:52
```

So lets use original doctrine/lexer instead.